### PR TITLE
myIpAddress should have a fallback

### DIFF
--- a/myIpAddress.js
+++ b/myIpAddress.js
@@ -4,6 +4,7 @@
  */
 
 var net = require('net');
+var ip = require('ip');
 
 /**
  * Module exports.
@@ -32,7 +33,11 @@ function myIpAddress (fn) {
   // 8.8.8.8:53 is "Google Public DNS":
   // https://developers.google.com/speed/public-dns/
   var socket = net.connect({ host: '8.8.8.8', port: 53 });
-  socket.once('error', fn);
+  socket.once('error', function(err) {
+    // if we fail to access Google DNS (as in firewall blocks access), 
+    // fallback to querying IP locally
+    fn(null, ip.address());
+  });
   socket.once('connect', function () {
     socket.removeListener('error', fn);
     var ip = socket.address().address;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "netmask": "~1.0.4",
     "degenerator": "~1.0.0",
     "regenerator": "~0.8.13",
-    "thunkify": "~2.1.1"
+    "thunkify": "~2.1.1",
+    "ip": "1.0.1"
   },
   "devDependencies": {
     "mocha": "2"


### PR DESCRIPTION
I ran into a problem using pac-proxy-agent. My IT have blocked access to google's DNS and when it tried to resolve the proxy.pac using pac-resolver, it would get connection denied as the myIpAddress calls would fail connecting to 8.8.8.8 to get the IP. 

I've added a fallback to get the local IP address using a module called IP.