### PR TITLE
Change myIpAddress to use the ip module to get local address.

### DIFF
--- a/myIpAddress.js
+++ b/myIpAddress.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var net = require('net');
+var ip = require('ip');
 
 /**
  * Module exports.
@@ -29,14 +29,5 @@ myIpAddress.async = true;
  */
 
 function myIpAddress (fn) {
-  // 8.8.8.8:53 is "Google Public DNS":
-  // https://developers.google.com/speed/public-dns/
-  var socket = net.connect({ host: '8.8.8.8', port: 53 });
-  socket.once('error', fn);
-  socket.once('connect', function () {
-    socket.removeListener('error', fn);
-    var ip = socket.address().address;
-    socket.destroy();
-    fn(null, ip);
-  });
+  return fn(null, ip.address());
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "dependencies": {
     "co": "~3.0.6",
-    "netmask": "~1.0.4",
     "degenerator": "~1.0.0",
+    "ip": "^1.0.2",
+    "netmask": "~1.0.4",
     "regenerator": "~0.8.13",
     "thunkify": "~2.1.1"
   },


### PR DESCRIPTION
Sending DNS request to 8.8.8.8 always times out behind a firewall
and this will make proxy autodetection slow or never return if we wait
for it to timeout and fail.  

Add a dependency on the ip module.

Signed-off-by: Rusty Conover <rusty@twosigma.com>