### PR TITLE
Escape regex characters in shExpMatch

### DIFF
--- a/shExpMatch.js
+++ b/shExpMatch.js
@@ -40,6 +40,7 @@ function shExpMatch (str, shexp) {
 
 function toRegExp (str) {
   str = String(str)
+    .replace(/\./g, '\\.')
     .replace(/\?/g, '.')
     .replace(/\*/g, '(.*)');
   return new RegExp('^' + str + '$');

--- a/test/shExpMatch.js
+++ b/test/shExpMatch.js
@@ -11,13 +11,13 @@ describe('shExpMatch(str, shexp)', function () {
   var tests = [
     ["http://home.netscape.com/people/ari/index.html", "*/ari/*", true],
     ["http://home.netscape.com/people/montulli/index.html", "*/ari/*", false],
-    ["http://home.example.com/people/index.html", ".*/people/.*", true],
     ["http://home.example.com/people/yourpage/index.html", ".*/mypage/.*", false],
     ["www.hotmail.com", "*hotmail.com*", true],
     ["phishing-scam.com?email=someone@hotmail.com", "*hotmail.com*", true],
     ["abcdomain.com", "(*.abcdomain.com|abcdomain.com)", true],
     ["foo.abcdomain.com", "(*.abcdomain.com|abcdomain.com)", true],
     ["abddomain.com", "(*.abcdomain.com|abcdomain.com)", false],
+    ["abcdomain.com", "*.n.com", false],
     ["a.com", "?.com", true],
     ["b.com", "?.com", true],
     ["ab.com", "?.com", false]


### PR DESCRIPTION
`*.t.com` matches `test.com`, which is unexpected.